### PR TITLE
Allows arrays in Like Clauses

### DIFF
--- a/src/FilterQueryString.php
+++ b/src/FilterQueryString.php
@@ -50,12 +50,18 @@ trait FilterQueryString {
 
     private function getFilters($filters)
     {
+        $passedFilters = ! empty($filters) && is_array($filters[0]) ? array_shift($filters) : null;
+                
         $filter = function ($key) use($filters) {
 
             $filters = $filters ?: $this->filters ?: [];
 
             return $this->unguardFilters != true ? in_array($key, $filters) : true;
         };
+        
+        if ($passedFilters) {
+            return array_filter($passedFilters, $filter, ARRAY_FILTER_USE_KEY) ?? [];
+        }
 
         return array_filter(request()->query(), $filter, ARRAY_FILTER_USE_KEY) ?? [];
     }

--- a/src/Filters/LikeClauses/WhereContainClause.php
+++ b/src/Filters/LikeClauses/WhereContainClause.php
@@ -6,9 +6,12 @@ trait WhereContainClause
 {
     private function contain($query, $filter, $values)
     {
-        foreach((array)$values as $value) {
-            $query->orWhere($filter, 'like', "%$value%");
-        }
+        $query->where(function($query) use($values, $filter) {
+            foreach((array)$values as $value) {
+                $query->orWhere($filter, 'like', "%$value%");
+            }
+        });
+        
         return $query;
     }
 }

--- a/src/Filters/LikeClauses/WhereEndWithClause.php
+++ b/src/Filters/LikeClauses/WhereEndWithClause.php
@@ -6,9 +6,12 @@ trait WhereEndWithClause
 {
     private function endWith($query, $filter, $values)
     {
-        foreach((array)$values as $value) {
-            $query->orWhere($filter, 'like', "%$value");
-        }
+        $query->where(function($query) use($values, $filter) {
+            foreach((array)$values as $value) {
+                $query->orWhere($filter, 'like', "%$value");
+            }
+        });
+        
         return $query;
     }
 }

--- a/src/Filters/LikeClauses/WhereLikeClause.php
+++ b/src/Filters/LikeClauses/WhereLikeClause.php
@@ -6,9 +6,12 @@ trait WhereLikeClause
 {
     private function like($query, $filter, $values)
     {
-        foreach((array)$values as $value) {
-            $query->orWhere($filter, 'like', "$value");
-        }
+        $query->where(function($query) use($values, $filter) {
+            foreach((array)$values as $value) {
+                $query->orWhere($filter, 'like', "$value");
+            }
+        });
+        
         return $query;
     }
 }

--- a/src/Filters/LikeClauses/WhereNotContainClause.php
+++ b/src/Filters/LikeClauses/WhereNotContainClause.php
@@ -6,9 +6,12 @@ trait WhereNotContainClause
 {
     private function notContain($query, $filter, $values)
     {
-        foreach((array)$values as $value) {
-            $query->orWhere($filter, 'not like', "%$value%");
-        }
+        $query->where(function($query) use($values, $filter) {
+            foreach((array)$values as $value) {
+                $query->orWhere($filter, 'not like', "%$value%");
+            }
+        });
+        
         return $query;
     }
 }

--- a/src/Filters/LikeClauses/WhereNotLikeClause.php
+++ b/src/Filters/LikeClauses/WhereNotLikeClause.php
@@ -6,9 +6,12 @@ trait WhereNotLikeClause
 {
     private function notLike($query, $filter, $values)
     {
-        foreach((array)$values as $value) {
-            $query->orWhere($filter, 'not like', "$value");
-        }
+        $query->where(function($query) use($values, $filter) {
+            foreach((array)$values as $value) {
+                $query->orWhere($filter, 'not like', "$value");
+            }
+        });
+       
         return $query;
     }
 }

--- a/src/Filters/LikeClauses/WhereStartWithClause.php
+++ b/src/Filters/LikeClauses/WhereStartWithClause.php
@@ -6,9 +6,12 @@ trait WhereStartWithClause
 {
     private function startWith($query, $filter, $values)
     {
-        foreach((array)$values as $value) {
-            $query->orWhere($filter, 'like', "$value%");
-        }
+        $query->where(function($query) use($values, $filter) {
+            foreach((array)$values as $value) {
+                $query->orWhere($filter, 'like', "$value%");
+            }
+        });
+      
         return $query;
     }
 }


### PR DESCRIPTION
### Fixes: 
Previous Like Clauses were being queried as "orWhere" causing unexpected results with multiple queries. This pull request changes it to a "where" clause.

**Example:** 
Before this query `users?username[contain]=farid&email[contain]=gmail` would return the following query: 

`select * from users where username like '%farid%' or email like '%gmail%'`

With this pull request the query will now be:

`select * from users where username like '%farid%' and email like '%gmail%'`

### Improves: 
Accepts arrays to allow multiple like clauses with the same filter.

**Example:** 
`users?username[contain][]=farid&username[contain][]=hossein` will return the following query:

`select * from users where (username like '%farid%' or username like '%hossein%')`