### PR TITLE
Manual passing filter array

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,3 +899,37 @@ Output:
 |:--------:|:--------------------------:|:----------:|:----:|:----------:|
 | mehrad   | mehrad<i></i>@startapp.id  | mehrad123  |  20  | 2020-09-01 |
 | hossein  | hossein<i></i>@startapp.id | hossein123 |  22  | 2020-11-01 |
+
+### Manually Passing Filter Array (Livewire)
+When using Livewire to filter data, subsequent query string changes do not trigger new requests. We can work around this by manually passing an array of filters.
+
+Example:
+```php
+User::filter(['username' => 'mehrad123'])->get();
+```
+
+Another example:
+```php
+User::filter([
+    'username' => [
+        'contain' => 'medhrad',
+    ],
+    'email' => [
+        'contain' => 'startapp.id',
+     ]
+])->get();
+```
+
+You can also combine this with conditional filters:
+```php
+User::filter([
+    'username' => 'mehrad123',
+    'email' => [
+        'contains' => 'startapp.id'
+    ]
+], 'username')->get();
+```
+
+The above would only query the username (not the email) since only the username was included as a conditional.
+
+**Note that the filter array must be passed before the conditionals.**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
         - [Is Not Null](#is-not-null)
     - [Custom Filters](#Custom-Filters)
     - [Conditional Filters](#Conditional-Filters)
-    - [Manually Passing Filter Array (Livewire)](#Manually-Passing-Filter-Array-(Livewire))
+    - [Manually Passing Filter Array (Livewire)](#Manually-Passing-Filter-Array-Livewire)
 
 ## Describing the Problem
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
         - [Is Not Null](#is-not-null)
     - [Custom Filters](#Custom-Filters)
     - [Conditional Filters](#Conditional-Filters)
+    - [Manually Passing Filter Array (Livewire)](#Manually-Passing-Filter-Array-(Livewire))
 
 ## Describing the Problem
 

--- a/src/FilterQueryString.php
+++ b/src/FilterQueryString.php
@@ -50,12 +50,18 @@ trait FilterQueryString {
 
     private function getFilters($filters)
     {
+        $passedFilters = ! empty($filters) && is_array($filters[0]) ? array_shift($filters) : null;
+                
         $filter = function ($key) use($filters) {
 
             $filters = $filters ?: $this->filters ?: [];
 
             return $this->unguardFilters != true ? in_array($key, $filters) : true;
         };
+        
+        if ($passedFilters) {
+            return array_filter($passedFilters, $filter, ARRAY_FILTER_USE_KEY) ?? [];
+        }
 
         return array_filter(request()->query(), $filter, ARRAY_FILTER_USE_KEY) ?? [];
     }


### PR DESCRIPTION
### Manually Passing Filter Array (Livewire)
When using Livewire to filter data, subsequent query string changes do not trigger new requests. We can work around this by manually passing an array of filters.

Example:
```php
User::filter(['username' => 'mehrad123'])->get();
```

Another example:
```php
User::filter([
    'username' => [
        'contain' => 'medhrad',
    ],
    'email' => [
        'contain' => 'startapp.id',
     ]
])->get();
```

You can also combine this with conditional filters:
```php
User::filter([
    'username' => 'mehrad123',
    'email' => [
        'contains' => 'startapp.id'
    ]
], 'username')->get();
```

The above would only query the username (not the email) since only the username was included as a conditional.

**Note that the filter array must be passed before the conditionals.**